### PR TITLE
Layout using stricter minmax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(PROJECT_NAME sss-guis)
 
-project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.6.1)
+project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.6.2)
 
 set(EXECUTABLE_NAME ${PROJECT_NAME}_executable)
 set(LIBRARY_NAME ${PROJECT_NAME}_library)

--- a/js/ts/widgets/layout.ts
+++ b/js/ts/widgets/layout.ts
@@ -63,7 +63,7 @@ export class layout_t extends widget_t {
             if (column < 0) {
                 throw new Error("A layout can only have a column with a size that is positive");
             }
-            return (column.toString() + "fr");
+            return ("minmax(0," + column.toString() + "fr)");
         }).join(" ");
         const rowsStyle: string = rows.map(row => {
             if (typeof row !== "number") {
@@ -75,7 +75,7 @@ export class layout_t extends widget_t {
             if (row < 0) {
                 throw new Error("A layout can only have a row with a size that is positive");
             }
-            return (row.toString() + "fr");
+            return ("minmax(0," + row.toString() + "fr)");
         }).join(" ");
         const gapStyle: string = (() => {
             if (this.configurationHas(configuration, "gap")) {


### PR DESCRIPTION
Layouts now enforce a `minmax` of `0` and the ratio e.g: `minmax(0, 2fr)`. This enforces stricter sizing instead of the browser default of `auto`.