### PR TITLE
Ensuring `null` widgets still occupy space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(PROJECT_NAME sss-guis)
 
-project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.6.9)
+project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.6.10)
 
 set(EXECUTABLE_NAME ${PROJECT_NAME}_executable)
 set(LIBRARY_NAME ${PROJECT_NAME}_library)

--- a/js/ts/widgets/void.ts
+++ b/js/ts/widgets/void.ts
@@ -12,7 +12,7 @@ export class void_t extends widget_t {
         this.content.innerText;
         const shadowRoot = this.content.attachShadow({ "mode": "closed" });
         const noDisplayStyling: CSSStyleSheet = new CSSStyleSheet();
-        noDisplayStyling.replaceSync(":host{all:initial;display:none;}");
+        noDisplayStyling.replaceSync(":host{all:initial!important;display:block!important;visibility:hidden!important;}");
         shadowRoot.adoptedStyleSheets = [noDisplayStyling];
     };
     public configuration(_configuration: Object): void {


### PR DESCRIPTION
Fixes bug: #13 

Replaces `display: none` with `visibility: hidden` to ensure `null` widgets still occupies space.