### PR TITLE
Emitting custom event for successful or unsuccessful structure rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(PROJECT_NAME sss-guis)
 
-project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.6.11)
+project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.6.12)
 
 set(EXECUTABLE_NAME ${PROJECT_NAME}_executable)
 set(LIBRARY_NAME ${PROJECT_NAME}_library)

--- a/js/ts/exported.ts
+++ b/js/ts/exported.ts
@@ -34,6 +34,26 @@ export function structureWidgetExists(identifier: widgetIdentifier_t): boolean {
     return structure_t.widgetExists(identifier);
 }
 /**
+ * The event type for successful structure rendering or error
+ * @returns {string} Event type
+ */
+export function structureLoadEventType(): string {
+    return "structureLoadEvent";
+};
+/**
+ * The event emitted on the successful completion of structure rendering or on error
+ */
+export interface structureLoadEvent {
+    /**
+     * Whether the structure loaded successfully
+     */
+    success: boolean;
+    /**
+     * Message to be set if an error occurred
+     */
+    message?: string;
+};
+/**
  * Exports functions to window
  * @internal
  */
@@ -41,6 +61,7 @@ export function exportToWindow(): void {
     (window as any).structureDeclareWidget = structureDeclareWidget;
     (window as any).structureWidget = structureWidget;
     (window as any).structureWidgetExists = structureWidgetExists;
+    (window as any).structureLoadEventType = structureLoadEventType;
     (window as any).widget_t = widget_t;
     (window as any).loadStylesheet = loadStylesheet;
     (window as any).loadModule = loadModule;

--- a/js/ts/index.ts
+++ b/js/ts/index.ts
@@ -6,7 +6,7 @@ import { structure_t } from "./structure";
 import { widget_t } from "./widgets/widget";
 import { loadStylesheet } from "./resources/stylesheet";
 import { registerCoreWidgets } from "./coreWidgets";
-import { exportToWindow } from "./exported";
+import { exportToWindow, structureLoadEvent, structureLoadEventType } from "./exported";
 import { loadModule, loadModules } from "./resources/module";
 
 // @internal
@@ -59,7 +59,12 @@ async function main(): Promise<void> {
                         document.documentElement.replaceChild(document.createElement("body"), splashContainer);
                         document.body.appendChild(mainElement);
                         document.title = gui_data!.name.trim() + " | SSS";
-                        document.dispatchEvent(new Event("load"));
+                        document.dispatchEvent(new CustomEvent<structureLoadEvent>(structureLoadEventType(), {
+                            detail: {
+                                success: true,
+                                message: undefined
+                            }
+                        }));
                         resolve();
                     }).catch((error) => {
                         reject(error);
@@ -71,6 +76,12 @@ async function main(): Promise<void> {
         }
     }).catch((error: any) => {
         setError(error as string);
+        document.dispatchEvent(new CustomEvent<structureLoadEvent>(structureLoadEventType(), {
+            detail: {
+                success: false,
+                message: (error as string),
+            }
+        }));
     });
 }
 


### PR DESCRIPTION
Implementing enhancement: #17 

A custom event will be emitted whether the structure was successfully rendered or not; with a conveniently accessible function to get the event type.