### PR TITLE
Widgets can now have complex structures defined by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(PROJECT_NAME sss-guis)
 
-project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.6.12)
+project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.7.0)
 
 set(EXECUTABLE_NAME ${PROJECT_NAME}_executable)
 set(LIBRARY_NAME ${PROJECT_NAME}_library)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The initial configuration file expects a YAML sequence (list) to be accessible u
 |`modules`|Sequence (list) of `string`s|*Optional* - A list of modules that are loaded into the GUI. Wildcards are allowed.|
 |`dependencies`|Sequence (list) of `string`s|*Optional* - Static unmanaged dependencies. Wildcards are allowed.|
 |`debug`|`boolean`|*Optional* - Wether to leave the names of widgets in the output files, otherwise it represents each widget as a numeric value.|
+|`defaults`|Map of complex widget structures|*Optional* - Default values for widgets.|
 
 An example structure could look like the following:
 ```yaml
@@ -36,9 +37,15 @@ guis:
    dependencies:
     - "example_dependency"
    debug: false
+   defaults:
+     example_widget_type:
+       example: property
+       property: example
 ```
 
 The `config` property will be used to load the main widget configuration file associated with the specific GUI.
+
+The `defaults` map allows you to define default [Widget Configurations](#widget-configurations) for specific widget types; reducing the need to repeat common values. The top levels keys within the `defaults` map represent the `type` of the widget. If a specific widget defines a property already listed in `defaults`, its local value will **override** the default.
 
 ### Widget configuration files
 Widget configuration files consist of descriptive structures used to define widgets, as well as *optional* links to additional `dependencies` defined in that file - as a sequence (list) of `string`s consisting of locations for additional configuration files - which will all be parsed resulting in additional widgets available to reference. This means that the `dependencies` keyword is reserved and widgets **cannot** be named it.

--- a/src/generation.cpp
+++ b/src/generation.cpp
@@ -164,6 +164,7 @@ generation_t::generation_t(std::filesystem::path const &configuration_file, std:
     : m_guis({}),
       m_dependencies({}),
       m_configuration_directory(std::filesystem::absolute(configuration_file.lexically_normal()).parent_path()),
+      m_configuration_file(configuration_file),
       m_output_directory(std::filesystem::absolute(output_directory.lexically_normal()))
 {
     std::vector<YAML::Node> gui_nodes = {};
@@ -332,6 +333,16 @@ generation_t::generation_t(std::filesystem::path const &configuration_file, std:
             else if (dependencies.Type() != YAML::NodeType::Null)
                 throw std::runtime_error("Unable to parse `dependencies` since a list is expected on line " + std::to_string(yaml_node_line_number(dependencies)) + " of \"" + configuration_file.string() + "\"");
         }
+
+        // Check whether widget defaults are listed
+        YAML::Node const widget_defaults = gui_node["defaults"];
+        if (widget_defaults.IsDefined())
+        {
+            // Expect a list of dependencies
+            if (!widget_defaults.IsMap())
+                throw std::runtime_error("Unable to parse `defaults` since a mappable structure is expected on line " + std::to_string(yaml_node_line_number(widget_defaults)) + " of \"" + configuration_file.string() + "\"");
+            current_gui_data.widget_defaults = widget_defaults;
+        }
         m_guis.push_back(current_gui_data); // Add to the collection
     }
     if (!std::filesystem::exists(m_output_directory))
@@ -368,7 +379,20 @@ void generation_t::generate(generation_t::gui_t const &data, std::string const &
     try
     {
         // Generate structure
-        structure = structure_t(data.source_configuration_file, data.name, debug_stream).build(register_dependency_callback_wrapper, !data.debug);
+        structure_t structure_parser(data.name, debug_stream);
+        if (data.widget_defaults.has_value())
+        {
+            try
+            {
+                structure_parser.populate_widget_defaults(data.widget_defaults.value());
+            }
+            catch (std::runtime_error const &e)
+            {
+                throw std::runtime_error(std::string(e.what()) + " of \"" + m_configuration_file.string() + "\"");
+            }
+        }
+        structure_parser.parse_file(std::filesystem::absolute(data.source_configuration_file).lexically_normal());
+        structure = structure_parser.build(register_dependency_callback_wrapper, !data.debug);
     }
     catch (std::exception const &e)
     {

--- a/src/generation.hpp
+++ b/src/generation.hpp
@@ -2,8 +2,10 @@
 
 #include <filesystem>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
+#include <yaml-cpp/yaml.h>
 #include "structure.hpp"
 
 namespace sss::guis
@@ -44,6 +46,10 @@ namespace sss::guis
              * @brief Paths of modules
              */
             std::vector<std::string> module_files;
+            /**
+             * @brief A map of YAML nodes consisting of the default values for defined widget type
+             */
+            std::optional<YAML::Node> widget_defaults;
         };
         /**
          * @brief Collection of all GUI's data
@@ -57,6 +63,10 @@ namespace sss::guis
          * @brief The output directory for all generated file
          */
         std::filesystem::path const m_configuration_directory;
+        /**
+         * @brief The path to the configuration file
+         */
+        std::filesystem::path const m_configuration_file;
         /**
          * @brief The source configuration file to find structures in
          */

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -44,6 +44,7 @@ namespace
                        { return std::tolower(character); });
         return string;
     }
+
     /**
      * @brief Validates whether a widget's name is value
      * @param name The name of the widget to validate
@@ -60,6 +61,7 @@ namespace
         if (name == "null")
             throw std::runtime_error("Cannot name a widget `" + name + "` as that name is not allowed");
     }
+
     /**
      * @brief Validates whether a widget's type is value
      * @param type The type of the widget to validate
@@ -73,6 +75,7 @@ namespace
         if (type.find_first_not_of(type_allowed_characters) != std::string_view::npos)
             throw std::runtime_error("Unable to declare a widget is of type `" + type + "` as it contains invalid characters");
     }
+
     /**
      * @brief Get the line number of a YAML Node object
      * @param node The YAML Node object to get the line number from
@@ -169,16 +172,16 @@ YAML_TO_JSON_STRING:
     }
 }
 
-structure_t::structure_t(std::string const &file, std::string const &name, std::ostream const *debug_stream)
+structure_t::structure_t(std::string const &name, std::ostream const *debug_stream)
     : m_widgets({}),
       m_widget_types({}),
       m_widget_contents({}),
+      m_widget_contents_defaults({}),
       m_widget_files({}),
       m_parsed_files({}),
       m_name(name),
       m_debug_stream(const_cast<std::ostream *>(debug_stream))
 {
-    parse_file(std::filesystem::absolute(file).lexically_normal());
 }
 
 structure_t::~structure_t()
@@ -190,9 +193,43 @@ structure_t::~structure_t()
     m_parsed_files.clear();
 }
 
-void structure_t::parse_file(std::filesystem::path const &file)
+void structure_t::populate_widget_defaults(widget_contents_t const &widget_defaults)
 {
-    std::vector<std::filesystem::path> dependency_files({file});
+    if (!widget_defaults.IsDefined())
+        return;
+    if (!widget_defaults.IsMap())
+        throw std::runtime_error("Unable to parse widget defaults since a mappable structure is expected on line " + std::to_string(yaml_node_line_number(widget_defaults))); // Should never be thrown (expected to be caught prior to construction of `structure_t` class)
+    for (auto const &widget_default : widget_defaults)
+    {
+        widget_type_t widget_type;
+        try
+        {
+            widget_type = to_lower(widget_default.first.as<widget_type_t>());
+            validate_widget_type(widget_type);
+        }
+        catch (YAML::Exception const &e)
+        {
+            throw std::runtime_error("Failed to parse the `type` (string) of configured widget default on line " + std::to_string(yaml_node_line_number(widget_default)));
+        }
+        catch (std::runtime_error const &e)
+        {
+            throw std::runtime_error(std::string(e.what()) + " on line " + std::to_string(yaml_node_line_number(widget_default)));
+        }
+        YAML::Node const type = widget_default.second["type"];
+        if (type.IsDefined())
+        {
+            if (!type.IsScalar() || (type.IsScalar() && type.as<widget_type_t>() != widget_type))
+                throw std::runtime_error("The widget default for the type `" + widget_type + "` has a conflicting yet redundant `type` definition - declared on line " + std::to_string(yaml_node_line_number(type)));
+            else
+                throw std::runtime_error("The widget default for the type `" + widget_type + "` has a redundant `type` definition - declared on line " + std::to_string(yaml_node_line_number(type)));
+        }
+        m_widget_contents_defaults.insert({widget_type, widget_default.second});
+    }
+}
+
+void structure_t::parse_file(std::filesystem::path const &configuration_file)
+{
+    std::vector<std::filesystem::path> dependency_files({configuration_file});
     do
     {
         std::filesystem::path const dependency_file = dependency_files.back();
@@ -271,11 +308,11 @@ void structure_t::parse_file(std::filesystem::path const &file)
                     widget_content_node.remove("type");
                     try
                     {
-                        add_widget(widget_name, widget_type, widget_content_node, static_cast<widget_file_reference_t>(m_parsed_files.size() - 1));
+                        add_widget(widget_name, widget_type, widget_entry.first, widget_content_node, static_cast<widget_file_reference_t>(m_parsed_files.size() - 1));
                     }
                     catch (std::runtime_error const &e)
                     {
-                        throw std::runtime_error(std::string(e.what()) + " on line " + std::to_string(yaml_node_line_number(widget_entry.first)) + " of \"" + dependency_file.string() + "\"");
+                        throw std::runtime_error(std::string(e.what()) + " of \"" + dependency_file.string() + "\"");
                     }
                 }
 
@@ -382,7 +419,7 @@ void structure_t::parse_file(std::filesystem::path const &file)
     } while (!dependency_files.empty());
 }
 
-void structure_t::add_widget(widget_name_t const &name, widget_type_t const &type, widget_contents_t const &contents, widget_file_reference_t const file_reference)
+void structure_t::add_widget(widget_name_t const &name, widget_type_t const &type, YAML::Node const &widget_base_node, widget_contents_t const &contents, widget_file_reference_t const file_reference)
 {
     widget_type_identifier_t type_id = -1;
     auto const it = std::find(m_widget_types.begin(), m_widget_types.end(), type);
@@ -395,9 +432,53 @@ void structure_t::add_widget(widget_name_t const &name, widget_type_t const &typ
     }
 
     if (m_widgets.count(name))
-        throw std::runtime_error("Duplicate definitions of the widget `" + name + "`");
+        throw std::runtime_error("Duplicate definitions of the widget `" + name + "` on line " + std::to_string(yaml_node_line_number(widget_base_node)));
+    if (m_widget_contents_defaults.count(type))
+    {
+        YAML::Node generated_output = YAML::Clone(m_widget_contents_defaults.at(type));
+        struct nodeComparison_t
+        {
+            YAML::Node generated_node;
+            YAML::Node defined_node;
+        };
+
+        std::vector<nodeComparison_t> processing_stack = {};
+        processing_stack.push_back({generated_output, contents});
+
+        while (!processing_stack.empty())
+        {
+            nodeComparison_t task = processing_stack.back();
+            processing_stack.pop_back();
+
+            YAML::Node &generated_node = task.generated_node;
+            YAML::Node const &defined_node = task.defined_node;
+
+            if (generated_node.IsDefined() && !generated_node.IsNull() && generated_node.Type() != defined_node.Type() && !defined_node.IsNull())
+                throw std::runtime_error("Structural conflict between widget `defaults` for the widget `" + name + "` of type `" + type + "` on line " + std::to_string(yaml_node_line_number(defined_node)));
+
+            if (defined_node.IsMap())
+            {
+                for (auto it = defined_node.begin(); it != defined_node.end(); ++it)
+                {
+                    std::string const key = it->first.as<std::string>();
+                    YAML::Node const source_value = it->second;
+                    if (generated_node[key])
+                        processing_stack.push_back({generated_node[key], source_value});
+                    else
+                        generated_node[key] = YAML::Clone(source_value);
+                }
+            }
+            else
+            {
+                if (!defined_node.IsNull())
+                    generated_node = YAML::Clone(defined_node); // Override default
+            }
+        }
+        m_widget_contents[name] = generated_output;
+    }
+    else
+        m_widget_contents[name] = contents;
     m_widgets[name] = type_id;
-    m_widget_contents[name] = contents;
     m_widget_files[name] = file_reference;
 }
 

--- a/src/structure.hpp
+++ b/src/structure.hpp
@@ -49,7 +49,11 @@ namespace sss::guis
         /**
          * @brief Collection of widget names and their contents
          */
-        std::map<widget_name_t, YAML::Node> m_widget_contents;
+        std::map<widget_name_t, widget_contents_t> m_widget_contents;
+        /**
+         * @brief Collection of widget types and their default contents
+         */
+        std::map<widget_type_t, widget_contents_t> m_widget_contents_defaults;
         /**
          * @brief Collection of widget names and their declaration file
          */
@@ -66,19 +70,14 @@ namespace sss::guis
          * @brief Output stream for debug messages
          */
         std::ostream *m_debug_stream;
-
-        /**
-         * @brief Parse a YAML file, handling dependencies and widgets
-         * @param file The YAML file to parse
-         */
-        void parse_file(std::filesystem::path const &file);
         /**
          * @brief Add a widget reference
          * @param name The name of the widget
          * @param type The type of the widget
          * @param contents The remaining contents of the widget
+         * @param file_reference The reference to the file of the widget's definition
          */
-        void add_widget(widget_name_t const &name, widget_type_t const &type, widget_contents_t const &contents, widget_file_reference_t const file_reference);
+        void add_widget(widget_name_t const &name, widget_type_t const &type, YAML::Node const &widget_base_node, widget_contents_t const &contents, widget_file_reference_t const file_reference);
         /**
          * @brief Convert object references to numerical references
          */
@@ -92,15 +91,24 @@ namespace sss::guis
     public:
         /**
          * @brief Construct a structure parser object that parsers YAML files into a JSON object
-         * @param configuration_file The source configuration file to start structuring from
          * @param name The name of the structure (only used for debug output)
          * @param debug_stream A `std::ofstream` to write debug outputs to
          */
-        structure_t(std::string const &configuration_file, std::string const &name, std::ostream const *debug_stream = nullptr);
+        structure_t(std::string const &name, std::ostream const *debug_stream = nullptr);
         /**
          * @brief Deconstructor
          */
         ~structure_t();
+        /**
+         * @brief Populate widgets with default properties
+         * @param widget_defaults A collection of default values for widgets of defined types
+         */
+        void populate_widget_defaults(widget_contents_t const &widget_defaults);
+        /**
+         * @brief Parse a YAML file, handling dependencies and widgets
+         * @param configuration_file The source configuration file to start structuring from
+         */
+        void parse_file(std::filesystem::path const &configuration_file);
         /**
          * @brief Build JSON output
          * @param path_register_dependency_callback Callback function to register a path as a dependency


### PR DESCRIPTION
Implements: #18 

Added a `defaults` map to the main GUI configuration. By mapping widget types to a default widget configuration structure, it reduces the need for repetitive common values while maintaining flexibility, as local widget definitions will still override these defaults; provided the underlying structure matches, if not, then an exception will be raised.

This change simplifies configuration management for complex GUIs and ensures a more consistent styling and behaviour baseline across all widgets of the same type.