### PR TITLE
Setting the configured name of widgets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(PROJECT_NAME sss-guis)
 
-project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.7.0)
+project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.7.1)
 
 set(EXECUTABLE_NAME ${PROJECT_NAME}_executable)
 set(LIBRARY_NAME ${PROJECT_NAME}_library)

--- a/js/ts/structure.ts
+++ b/js/ts/structure.ts
@@ -132,6 +132,7 @@ export abstract class structure_t {
             throw new Error(`Unable to create widget of "${type}" which is an unknown widget type`);
         }
         let widget: widget_t = this.widgetDeclarations[type]();
+        widget.configurationName(identifier.toString());
         // @ts-ignore - to allow either a number or a string to be an index
         widget.configuration(this.structure.widgets[identifier][widgetData_t.widgetDataConfiguration] || {});
         return widget;

--- a/js/ts/widgets/widget.ts
+++ b/js/ts/widgets/widget.ts
@@ -23,6 +23,18 @@ export abstract class widget_t {
         this.content.className = type;
     }
     /**
+     * Configure a widget's name
+     * @param {string} name Name of widget
+     * @internal
+     */
+    public configurationName(name: string): void {
+        const originalName: (string | null) = this.content.getAttribute("name");
+        if (originalName !== null) {
+            console.warn(`The widget named "${originalName}" is being renamed to "${name}"`);
+        }
+        this.content.setAttribute("name", name);
+    }
+    /**
      * @abstract Configure a widget
      * @param {Object} configuration Contents of widget
      */


### PR DESCRIPTION
Implements: #20 

The names of widgets are set on the rendered widgets.

If the GUI is **not** generated with `debug` set to `true` then automatically generated numerical "names" will be used instead. Hence the benefit of this implementation is best served alongside `debug` mode generations.
