### PR TITLE
Prepending the name of the widget in the raised errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(PROJECT_NAME sss-guis)
 
-project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.8.0)
+project(${PROJECT_NAME} LANGUAGES CXX VERSION 0.8.1)
 
 set(EXECUTABLE_NAME ${PROJECT_NAME}_executable)
 set(LIBRARY_NAME ${PROJECT_NAME}_library)

--- a/js/ts/index.ts
+++ b/js/ts/index.ts
@@ -24,6 +24,7 @@ async function main(): Promise<void> {
     splashStatus.innerText = "Loading...";
     const setError = (error: string): void => {
         splashStatus.innerText = error;
+        splashStatus.classList.add("error")
         document.title = "Error | SSS";
     };
     splashContent.appendChild(splashHeading);
@@ -36,7 +37,7 @@ async function main(): Promise<void> {
         try {
             gui_data = new gui_t();
         } catch (error: any) {
-            reject(error);
+            reject(error.message);
         }
         exportToWindow();
         try {
@@ -67,19 +68,21 @@ async function main(): Promise<void> {
                         }));
                         resolve();
                     }).catch((error) => {
-                        reject(error);
+                        reject(error.message);
                     });
                 }
-            })
+            }).catch((error: any) => {
+                reject((error instanceof Error) ? error.message : error);
+            });
         } catch (error: any) {
             reject(error);
         }
-    }).catch((error: any) => {
-        setError(error as string);
+    }).catch((error: string) => {
+        setError(error);
         document.dispatchEvent(new CustomEvent<structureLoadEvent>(structureLoadEventType(), {
             detail: {
                 success: false,
-                message: (error as string),
+                message: error,
             }
         }));
     });

--- a/js/ts/splash.scss
+++ b/js/ts/splash.scss
@@ -27,5 +27,8 @@ div {
         margin: auto;
         font-family: monospace;
         color: darkslategray;
+        &.error {
+            color: red;
+        }
     }
 }

--- a/js/ts/widgets/audio.ts
+++ b/js/ts/widgets/audio.ts
@@ -14,7 +14,7 @@ export class audio_t extends widget_t {
     protected source!: string;
     public configuration(configuration: Object): void {
         if (!this.configurationHas(configuration, "source")) {
-            throw new Error("Missing audio `source` for an audio widget");
+            this.raiseError("Missing audio `source` for an audio widget");
         }
         this.source = (configuration as any).source as string;
     }
@@ -42,7 +42,13 @@ export class audio_t extends widget_t {
                 this.content.onerror = () => failure();
                 (this.content as HTMLAudioElement).load();
                 resolve(this.content);
-            }).catch((error) => reject(error));
+            }).catch((error) => {
+                try {
+                    this.raiseError(error)
+                } catch (error) {
+                    reject(error);
+                }
+            });
         });
     };
 };

--- a/js/ts/widgets/container.ts
+++ b/js/ts/widgets/container.ts
@@ -21,15 +21,15 @@ export class container_t extends widget_t {
             if ((typeof (configuration as any).title === "string" || typeof (configuration as any).title === "number")) {
                 this.title = (configuration as any).title.toString();
             } else {
-                throw new Error("A container needs a title to be either a string or a number");
+                this.raiseError("A container needs a `title` to be either a string or a number");
             }
         } else {
-            throw new Error("A container needs a title");
+            this.raiseError("A container needs a `title`");
         }
         if (this.configurationHas(configuration, "object")) {
             this.object = structure_t.widget((configuration as any).object);
         } else {
-            throw new Error("A container has no reference to an object");
+            this.raiseError("A container has no reference to an `object`");
         }
     }
     public render(): Promise<HTMLElement> {

--- a/js/ts/widgets/image.ts
+++ b/js/ts/widgets/image.ts
@@ -20,7 +20,7 @@ export class image_t extends widget_t {
     private source!: string;
     public configuration(configuration: Object): void {
         if (!this.configurationHas(configuration, "source")) {
-            throw new Error("Missing image `source` for an image widget");
+            this.raiseError("Missing image `source` for an image widget");
         }
         this.source = (configuration as any).source as string;
         if (this.configurationHas(configuration, "contain")) {
@@ -31,7 +31,7 @@ export class image_t extends widget_t {
                     this.content.setAttribute("contain", contain);
                     break;
                 default:
-                    throw new Error(`"${contain}" is not a valid \`contain\` property for a video widget`);
+                    this.raiseError(`"${contain}" is not a valid \`contain\` property for a video widget`);
             }
         }
     }
@@ -41,7 +41,13 @@ export class image_t extends widget_t {
                 this.content.onload = () => resolve(this.content);
                 this.content.onerror = () => reject(`An image resource of type "${resource.mimeType}" is not supported in this browser`);
                 (this.content as HTMLImageElement).src = resource.blobUrl;
-            }).catch((error) => reject(error));
+            }).catch((error) => {
+                try {
+                    this.raiseError(error)
+                } catch (error) {
+                    reject(error);
+                }
+            });
         });
     };
 };

--- a/js/ts/widgets/layout.ts
+++ b/js/ts/widgets/layout.ts
@@ -23,25 +23,25 @@ export class layout_t extends widget_t {
     public configuration(configuration: Object): void {
         if (!this.configurationHas(configuration, "columns") ||
             !Array.isArray((configuration as any).columns)) {
-            throw new Error("A layout needs a numeric set of `columns`");
+            this.raiseError("A layout needs a numeric set of `columns`");
         }
         if (!this.configurationHas(configuration, "rows") ||
             !Array.isArray((configuration as any).rows)) {
-            throw new Error("A layout needs a numeric set of `rows`");
+            this.raiseError("A layout needs a numeric set of `rows`");
         }
         const columns: number[] = (configuration as any).columns;
         const rows: number[] = (configuration as any).rows;
         const maxItems: number = (columns.length * rows.length);
         if (this.configurationHas(configuration, "items")) {
             if (!Array.isArray((configuration as any).items)) {
-                throw new Error("A layout's `items` must be a list");
+                this.raiseError("A layout's `items` must be a list");
             }
             (configuration as any).items.forEach((item: any) => {
                 if (this.children.length == maxItems) {
-                    throw new Error("Attempting to add too many items to a layout (consider increasing `columns` or `rows`)");
+                    this.raiseError("Attempting to add too many items to a layout (consider increasing `columns` or `rows`)");
                 }
                 if (!this.configurationHas(item, "object")) {
-                    throw new Error("Layout item has no reference to an object");
+                    this.raiseError("Layout item has no reference to an `object`");
                 }
                 if (item.object === null) {
                     this.children.push(new void_t());
@@ -55,25 +55,25 @@ export class layout_t extends widget_t {
         }
         const columnsStyle: string = columns.map(column => {
             if (typeof column !== "number") {
-                throw new Error(`A layout requires a numerical column size - not "${column}"`);
+                this.raiseError(`A layout requires a numerical column size - not "${column}"`);
             }
             if (column == 0) {
                 return "auto";
             }
             if (column < 0) {
-                throw new Error("A layout can only have a column with a size that is positive");
+                this.raiseError("A layout can only have a column with a size that is positive");
             }
             return ("minmax(0," + column.toString() + "fr)");
         }).join(" ");
         const rowsStyle: string = rows.map(row => {
             if (typeof row !== "number") {
-                throw new Error(`A layout requires a numerical row size - not "${row}"`);
+                this.raiseError(`A layout requires a numerical row size - not "${row}"`);
             }
             if (row == 0) {
                 return "auto";
             }
             if (row < 0) {
-                throw new Error("A layout can only have a row with a size that is positive");
+                this.raiseError("A layout can only have a row with a size that is positive");
             }
             return ("minmax(0," + row.toString() + "fr)");
         }).join(" ");
@@ -81,7 +81,7 @@ export class layout_t extends widget_t {
             if (this.configurationHas(configuration, "gap")) {
                 const gap: any = (configuration as any).gap;
                 if (typeof gap !== "boolean") {
-                    throw new Error("A layout has a `gap` property but is not a boolean value");
+                    this.raiseError("A layout has a `gap` property but is not a boolean value");
                 }
                 if (gap === false) {
                     return "gap:0!important;grid-gap:0!important;";

--- a/js/ts/widgets/tabs.ts
+++ b/js/ts/widgets/tabs.ts
@@ -30,26 +30,26 @@ export class tabs_t extends widget_t {
     public configuration(configuration: Object): void {
         if (!this.configurationHas(configuration, "items") ||
             !Array.isArray((configuration as any).items)) {
-            throw new Error("A tabs widget is missing `items`");
+            this.raiseError("A tabs widget is missing `items`");
         }
         ((configuration as any).items as Object[]).forEach((item: any) => {
             if (!this.configurationHas(item, "name")) {
-                throw new Error("A tab name is expected");
+                this.raiseError("A tab `name` is expected");
             }
             if (!(typeof item.name === "string" || typeof item.name === "number")) {
-                throw new Error("A tab name needs to be either a string or a number");
+                this.raiseError("A tab `name` needs to be either a string or a number");
             }
             const tabName: string = item.name.toString();
             if (tabName in this.tabs) {
-                throw new Error(`Another tab exists with the name of "${tabName}" within a tab widget`);
+                this.raiseError(`Another tab exists with the name of "${tabName}" within a tab widget`);
             }
             if (!this.configurationHas(item, "object")) {
-                throw new Error(`Tab "${tabName}" has no reference to an object`);
+                this.raiseError(`Tab "${tabName}" has no reference to an \`object\``);
             }
             this.tabs[tabName] = structure_t.widget(item.object);
         });
         if (Object.keys(this.tabs).length == 0) {
-            throw new Error("A tabs widget is missing `items`");
+            this.raiseError("A tabs widget is missing `items`");
         }
         if (this.configurationHas(configuration, "position")) {
             do {
@@ -63,11 +63,11 @@ export class tabs_t extends widget_t {
                             this.position = position;
                             break;
                         default:
-                            throw new Error(`"${position}" is not a valid position for a collection of tabs`);
+                            this.raiseError(`"${position}" is not a valid position for a collection of tabs`);
                     }
                     break;
                 }
-                throw new Error("The `position` for a collection of tabs must be a string");
+                this.raiseError("The `position` for a collection of tabs must be a string");
             } while (false);
         }
         this.content.setAttribute("position", this.position);

--- a/js/ts/widgets/textual.ts
+++ b/js/ts/widgets/textual.ts
@@ -27,7 +27,7 @@ const textualAlignmentVerticalAttribute: string = "valign";
 export abstract class textual_t extends widget_t {
     public setConfiguration(configuration: Object, textualAlignmentHorizontalDefault: textualAlignmentHorizontal_t, textualAlignmentVerticalDefault: textualAlignmentVertical_t): void {
         if (!this.configurationHas(configuration, "text")) {
-            throw new Error(`A ${this.content.className} widget requires \`text\` to be shown`);
+            this.raiseError(`A ${this.content.className} widget requires \`text\` to be shown`);
         }
         this.content.innerText = (configuration as any).text as string;
         if (this.configurationHas(configuration, "alignment")) {
@@ -41,7 +41,7 @@ export abstract class textual_t extends widget_t {
                         this.content.setAttribute(textualAlignmentHorizontalAttribute, horizontalAlignment);
                         break;
                     default:
-                        throw new Error(`"${horizontalAlignment}" is not a valid horizontal alignment for a ${this.content.className} widget`);
+                        this.raiseError(`"${horizontalAlignment}" is not a valid \`horizontal\` \`alignment\` for a ${this.content.className} widget`);
                 }
             } else {
                 this.content.setAttribute(textualAlignmentHorizontalAttribute, textualAlignmentHorizontalDefault);
@@ -55,7 +55,7 @@ export abstract class textual_t extends widget_t {
                         this.content.setAttribute(textualAlignmentVerticalAttribute, verticalAlignment);
                         break;
                     default:
-                        throw new Error(`"${verticalAlignment}" is not a valid vertical alignment for a ${this.content.className} widget`);
+                        this.raiseError(`"${verticalAlignment}" is not a valid \`vertical\` \`alignment\` for a ${this.content.className} widget`);
                 }
             } else {
                 this.content.setAttribute(textualAlignmentVerticalAttribute, textualAlignmentVerticalDefault);
@@ -77,7 +77,7 @@ export abstract class textual_t extends widget_t {
             }
             const color: string = (configuration as any).color;
             if (!isColor(color)) {
-                throw new Error(`"${color}" is not a valid color for a ${this.content.className} widget`);
+                this.raiseError(`"${color}" is not a valid \`color\` for a ${this.content.className} widget`);
             }
             const textualShadowRoot: ShadowRoot = this.content.attachShadow({ mode: "closed" });
             const noInheritedStyling: CSSStyleSheet = new CSSStyleSheet();

--- a/js/ts/widgets/video.ts
+++ b/js/ts/widgets/video.ts
@@ -20,7 +20,7 @@ export class video_t extends widget_t {
     private source!: string;
     public configuration(configuration: Object): void {
         if (!this.configurationHas(configuration, "source")) {
-            throw new Error("Missing video `source` for a video widget");
+            this.raiseError("Missing video `source` for a video widget");
         }
         this.source = (configuration as any).source as string;
         if (this.configurationHas(configuration, "contain")) {
@@ -31,7 +31,7 @@ export class video_t extends widget_t {
                     this.content.setAttribute("contain", contain);
                     break;
                 default:
-                    throw new Error(`"${contain}" is not a valid \`contain\` property for a video widget`);
+                    this.raiseError(`"${contain}" is not a valid \`contain\` property for a video widget`);
             }
         }
     };
@@ -59,7 +59,13 @@ export class video_t extends widget_t {
                 (this.content as HTMLVideoElement).oncanplaythrough = () => resolve(this.content);
                 this.content.onerror = () => failure();
                 (this.content as HTMLVideoElement).load();
-            }).catch((error) => reject(error));
+            }).catch((error) => {
+                try {
+                    this.raiseError(error)
+                } catch (error) {
+                    reject(error);
+                }
+            });
         });
     };
 };

--- a/js/ts/widgets/widget.ts
+++ b/js/ts/widgets/widget.ts
@@ -58,4 +58,18 @@ export abstract class widget_t {
             return false;
         }
     }
+    /**
+     * Raise an error originating from a specific widget
+     * @param {any} error The error to raise (can be an Error itself)
+     */
+    protected raiseError(error: any): never {
+        const name: (string | null) = this.content.getAttribute("name");
+        const errorType: any = (error instanceof Error ? (error.constructor as any) : Error);
+        const formattedError = new errorType(`${(name !== null && name.trim().length > 0) ? `${name}: ` : ""}${error instanceof Error ? error.message : String(error)}`);
+        // If it was an Error object preserve the stack trace
+        if (error instanceof Error) {
+            formattedError.stack = error.stack;
+        }
+        throw formattedError;
+    }
 };


### PR DESCRIPTION
Implementing: #26

Error messages originating from the GUI rendering process are now prepended with the name of the offending widget. Error messages shown here are best served when the GUI is generated with `debug` set to `true`; as when set to `false` automatically generated numerical "names" are used instead.