### PR TITLE
Configurable project definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME sss-guis)
 project(${PROJECT_NAME}
         LANGUAGES CXX
-        VERSION 0.8.5
+        VERSION 0.8.6
         DESCRIPTION "An extensible YAML to graphical web application system")
 
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ The initial configuration file expects a YAML sequence (list) to be accessible u
 |`debug`|`boolean`|*Optional* - Wether to leave the names of widgets in the output files, otherwise it represents each widget as a numeric value.|
 |`defaults`|Map of complex widget structures|*Optional* - Default values for widgets.|
 
+Extra configurable properties for the entire project are optionally defined at the root of the YAML document (not part of the `guis` sequence):
+|Property|Type|Meaning|
+|-|-|-|
+|`project`|`string`|*Optional* - The name of the project, this will be appended to each GUI title.|
+|`project_delimiter`|`string`|*Optional* - The delimiter to be between the GUI title and the `project`.|
+
+
 An example structure could look like the following:
 ```yaml
 guis:

--- a/js/build.js
+++ b/js/build.js
@@ -34,6 +34,9 @@ async function build() {
         format: "iife",
         target: "es2019",
         outfile: "dist/" + bundleName + ".js",
+        banner: {
+            js: "// SSS-GUIS"
+        },
         plugins: [
             {
                 name: "scss-string",

--- a/js/ts/gui.ts
+++ b/js/ts/gui.ts
@@ -15,6 +15,11 @@ interface gui_schema_t {
      */
     name: string;
     /**
+     * The name of the project
+     * @internal
+     */
+    project: string;
+    /**
      * The path to the structure of the GUI
      * @internal
      */
@@ -48,6 +53,11 @@ export class gui_t {
      */
     public name!: string;
     /**
+     * The name of the project
+     * @internal
+     */
+    public project!: string;
+    /**
      * The path to the structure of the GUI
      * @internal
      */
@@ -63,6 +73,7 @@ export class gui_t {
         }
         this.modules = gui.modules;
         this.name = gui.name;
+        this.project = gui.project;
         this.structure = gui.structure
         this.stylesheet = gui.stylesheet;
     }

--- a/js/ts/index.ts
+++ b/js/ts/index.ts
@@ -11,6 +11,7 @@ import { loadModule, loadModules } from "./resources/module";
 
 // @internal
 async function main(): Promise<void> {
+    let projectName: string = "SSS";
     // Splash screen
     const splashContainer: HTMLBodyElement = document.createElement("body");
     const splashShadowRoot: ShadowRoot = splashContainer.attachShadow({ "mode": "closed" });
@@ -19,13 +20,13 @@ async function main(): Promise<void> {
     splashShadowRoot.adoptedStyleSheets = [noInheritedStyling];
     const splashContent: HTMLDivElement = document.createElement("div");
     const splashHeading: HTMLHeadingElement = document.createElement("h1");
-    splashHeading.innerText = "SSS";
+    splashHeading.innerText = projectName;
     const splashStatus: HTMLParagraphElement = document.createElement("p");
     splashStatus.innerText = "Loading...";
     const setError = (error: string): void => {
         splashStatus.innerText = error;
         splashStatus.classList.add("error")
-        document.title = "Error | SSS";
+        document.title = `Error | ${projectName}`;
     };
     splashContent.appendChild(splashHeading);
     splashContent.appendChild(splashStatus);
@@ -36,6 +37,8 @@ async function main(): Promise<void> {
         let gui_data: (gui_t | null) = null;
         try {
             gui_data = new gui_t();
+            projectName = gui_data.project;
+            splashHeading.innerText = projectName;
         } catch (error: any) {
             reject(error.message);
         }
@@ -59,7 +62,7 @@ async function main(): Promise<void> {
                         }
                         document.documentElement.replaceChild(document.createElement("body"), splashContainer);
                         document.body.appendChild(mainElement);
-                        document.title = gui_data!.name.trim() + " | SSS";
+                        document.title = gui_data!.name.trim();
                         document.dispatchEvent(new CustomEvent<structureLoadEvent>(structureLoadEventType(), {
                             detail: {
                                 success: true,

--- a/src/generation.cpp
+++ b/src/generation.cpp
@@ -17,6 +17,16 @@ using namespace sss::guis;
 namespace
 {
     /**
+     * @brief The default project name
+     */
+    std::string const project_default = "SSS";
+
+    /**
+     * @brief The default project delimiter
+     */
+    std::string const project_delimiter_default = " | ";
+
+    /**
      * @brief Check if a string is empty
      * @param string The string to check
      * @returns Whether the string is empty
@@ -167,18 +177,20 @@ generation_t::generation_t(std::filesystem::path const &configuration_file, std:
       m_configuration_file(configuration_file),
       m_output_directory(std::filesystem::absolute(output_directory.lexically_normal()))
 {
-    std::vector<YAML::Node> gui_nodes = {};
+    std::vector<std::tuple<YAML::Node, YAML::Node, YAML::Node>> gui_nodes = {};
     try
     {
         for (auto const &document : YAML::LoadAllFromFile(configuration_file.string()))
         {
             if (!document.IsDefined())
                 continue;
+            YAML::Node const project_name = document["project"];
+            YAML::Node const project_name_delimiter = document["project_delimiter"];
             YAML::Node const guis = document["guis"];
             if (!guis.IsDefined() || !guis.IsSequence())
                 continue;
             for (auto &&gui : guis)
-                gui_nodes.push_back(gui);
+                gui_nodes.emplace_back(gui, project_name, project_name_delimiter);
         }
         if (gui_nodes.empty())
             throw std::runtime_error("Expected list of `guis` in configuration");
@@ -187,7 +199,7 @@ generation_t::generation_t(std::filesystem::path const &configuration_file, std:
     {
         throw std::runtime_error("Failed to load descriptive YAML file \"" + configuration_file.string() + "\" due to an error on line " + std::to_string(yaml_mark_line_number(e.mark)) + ": " + e.msg);
     }
-    for (YAML::Node const &gui_node : gui_nodes)
+    for (auto const &[gui_node, project_name, project_delimiter] : gui_nodes)
     {
         if (!gui_node.IsMap())
             throw std::runtime_error("Expected `gui` to hold a defined configuration on line " + std::to_string(yaml_node_line_number(gui_node)) + " of \"" + configuration_file.string() + "\"");
@@ -217,6 +229,28 @@ generation_t::generation_t(std::filesystem::path const &configuration_file, std:
         current_gui_data.name = name.as<std::string>();
         if (is_empty(current_gui_data.name))
             throw std::runtime_error("A name must not be empty on line " + std::to_string(yaml_node_line_number(name)) + " of \"" + configuration_file.string() + "\"");
+
+        // Store name of project
+        try
+        {
+            current_gui_data.project = project_name.as<std::string>(project_default);
+        }
+        catch (YAML::BadConversion const &e)
+        {
+            throw std::runtime_error("Invalid `project` name only a string is expected on line " + std::to_string(yaml_node_line_number(project_name)) + " of \"" + configuration_file.string() + "\"");
+        }
+        if (is_empty(current_gui_data.project))
+            throw std::runtime_error("Invalid `project` name must not be empty on line " + std::to_string(yaml_node_line_number(project_name)) + " of \"" + configuration_file.string() + "\"");
+
+        // Store project delimiter (this is allowed to be empty)
+        try
+        {
+            current_gui_data.project_delimiter = project_delimiter.as<std::string>(project_delimiter_default);
+        }
+        catch (YAML::BadConversion const &e)
+        {
+            throw std::runtime_error("Invalid `project_delimiter` name only a string is expected on line " + std::to_string(yaml_node_line_number(project_delimiter)) + " of \"" + configuration_file.string() + "\"");
+        }
 
         // Store configuration filepath of GUI
         auto const config = gui_node["config"];
@@ -411,13 +445,14 @@ void generation_t::generate(generation_t::gui_t const &data, std::string const &
 
     // GUI JSON object
     nlohmann::json gui_info = {
-        {"name", data.name},
+        {"project", data.project},
+        {"name", data.name + data.project_delimiter + data.project},
         {"structure", relative_adjustment + structure_file},
         {"stylesheet", relative_adjustment + data.stylesheet_file},
         {"modules", modules}};
 
     // Generate HTML
-    std::string html = "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>SSS</title><script type=\"text/javascript\">const gui=" + gui_info.dump() + ";</script><script type=\"text/javascript\" src=\"/" + guis_js_path + "\"></script></head><body><noscript>Browser not supported: JavaScript required!</noscript></body></html>";
+    std::string html = "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>" + data.project + "</title><script type=\"text/javascript\">const gui=" + gui_info.dump() + ";</script><script type=\"text/javascript\" src=\"/" + guis_js_path + "\"></script></head><body><noscript>Browser not supported: JavaScript required!</noscript></body></html>";
 
     /**
      * @brief Write contents to a file

--- a/src/generation.hpp
+++ b/src/generation.hpp
@@ -23,6 +23,14 @@ namespace sss::guis
              */
             std::string name;
             /**
+             * @brief The project parent for the GUI
+             */
+            std::string project;
+            /**
+             * @brief The project parent delimiter for the GUI
+             */
+            std::string project_delimiter;
+            /**
              * @brief Whether the GUI should be generated with debug mode
              */
             bool debug;


### PR DESCRIPTION
Implements #37 

Added `project` and `project_delimiter` properties to the main configuration file, this overrides the internal defaults for each, allowing for fully user configurable titles to be defined.